### PR TITLE
Support systemd status to return 0 exit code when status OK #4

### DIFF
--- a/package/scripts/cassandra_master.py
+++ b/package/scripts/cassandra_master.py
@@ -52,7 +52,12 @@ class Cassandra_Master(Script):
     def status(self, env):
         import params
         env.set_params(params)
-        status_cmd = format("service cassandra status")
+        status_cmd = format("""
+            if hash systemctl 2>/dev/null; then
+              systemctl status cassandra
+            else
+              service cassandra status
+            fi""")
         Execute(status_cmd)
         print 'Status of the Master'
     


### PR DESCRIPTION
CentOS 7 uses systemd.  For some reason even when the `cassandra` service is running OK, a `service cassandra status` will return a non-zero exit code which causes the Ambari status handler to fail.  This fix will use `systemctl` to get the status when it exists on the path.
